### PR TITLE
Feature/prod 2359

### DIFF
--- a/flask_restplus/__about__.py
+++ b/flask_restplus/__about__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.13.1.dev+iai.2'
+__version__ = '0.13.1.dev+iai.3'
 __description__ = 'Fully featured framework for fast, easy and documented API development with Flask'

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -25,7 +25,10 @@ from flask.signals import got_request_exception
 
 from jsonschema import RefResolver
 
-from werkzeug import cached_property
+try:
+    from werkzeug.utils import cached_property
+except:
+    from werkzeug import cached_property
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
 from werkzeug.wrappers import BaseResponse

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -27,7 +27,7 @@ from jsonschema import RefResolver
 
 try:
     from werkzeug.utils import cached_property
-except:
+except ImportError:
     from werkzeug import cached_property
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -185,6 +185,7 @@ class Api(object):
         self.license = kwargs.get('license', self.license)
         self.license_url = kwargs.get('license_url', self.license_url)
         self._add_specs = kwargs.get('add_specs', True)
+        self._hide_specs_url = kwargs.get('hide_specs_url', False)
 
         # If app is a blueprint, defer the initialization
         try:
@@ -244,7 +245,7 @@ class Api(object):
         conf['apidoc_registered'] = True
 
     def _register_specs(self, app_or_blueprint):
-        if self._add_specs:
+        if self._add_specs and not self._hide_specs_url:
             endpoint = str('specs')
             self._register_view(
                 app_or_blueprint,

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -249,9 +249,7 @@ class Api(object):
         conf['apidoc_registered'] = True
 
     def _register_specs(self, app_or_blueprint):
-        if self._hide_specs_url:
-            app_or_blueprint.add_url_rule('/swagger.json', 'specs', self.render_spec)
-        elif self._add_specs:
+        if self._add_specs and not self._hide_specs_url:
             endpoint = str('specs')
             self._register_view(
                 app_or_blueprint,
@@ -386,7 +384,9 @@ class Api(object):
     def specs(self, func):
         '''A decorator to specify a view function for the specs'''
         self._hide_specs_url = True
+        app = self.app or self.Blueprint
         self._spec_view = func
+        app.add_url_rule('/swagger.json', 'specs', self.render_spec)
         return func
 
     def render_root(self):

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -383,9 +383,10 @@ class Api(object):
 
     def specs(self, func):
         '''A decorator to specify a view function for the specs'''
-        self._hide_specs_url = True
+        self._spec_view = partial(apidoc.specs_for, self)
+        if func:
+            self._spec_view = func
         app = self.app or self.Blueprint
-        self._spec_view = func
         app.add_url_rule('/swagger.json', 'specs', self.render_spec)
         return func
 

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import url_for, Blueprint, render_template, jsonify
+import json
+from flask import url_for, Blueprint, render_template, Response
 
 
 class Apidoc(Blueprint):
@@ -40,4 +41,5 @@ def ui_for(api):
 
 
 def specs_for(api):
-    return jsonify(api.__schema__)
+    swagger_specs = json.dumps(api.__schema__, sort_keys=True, indent=4, separators=(',', ': '))
+    return Response(swagger_specs, mimetype='application/json')

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import url_for, Blueprint, render_template
+from flask import url_for, Blueprint, render_template, jsonify
 
 
 class Apidoc(Blueprint):
@@ -37,3 +37,7 @@ def ui_for(api):
         specs_json=api.__schema__, specs_url=None)
     return render_template('swagger-ui.html', title=api.title,
                            specs_url=api.specs_url)
+
+
+def specs_for(api):
+    return jsonify(api.__schema__)

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import json
 from flask import url_for, Blueprint, render_template, Response
+from ._http import HTTPStatus
 
 
 class Apidoc(Blueprint):
@@ -33,13 +34,11 @@ def swagger_static(filename):
 
 def ui_for(api):
     '''Render a SwaggerUI for a given API'''
-    if api._hide_specs_url:
-        return render_template('swagger-ui.html', title=api.title,
-        specs_json=api.__schema__, specs_url=None)
     return render_template('swagger-ui.html', title=api.title,
-                           specs_url=api.specs_url)
+        specs_json=api.__schema__)
 
 
 def specs_for(api):
     swagger_specs = json.dumps(api.__schema__, sort_keys=True, indent=4, separators=(',', ': '))
-    return Response(swagger_specs, mimetype='application/json')
+    return Response(swagger_specs, mimetype='application/json'),
+    HTTPStatus.INTERNAL_SERVER_ERROR if 'error' in api.__schema__ else HTTPStatus.OK

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import json
 from flask import url_for, Blueprint, render_template, Response
-from ._http import HTTPStatus
 
 
 class Apidoc(Blueprint):
@@ -40,5 +39,6 @@ def ui_for(api):
 
 def specs_for(api):
     swagger_specs = json.dumps(api.__schema__, sort_keys=True, indent=4, separators=(',', ': '))
-    return Response(swagger_specs, mimetype='application/json'),
-    HTTPStatus.INTERNAL_SERVER_ERROR if 'error' in api.__schema__ else HTTPStatus.OK
+    if 'error' in api.__schema__:
+        return Response(swagger_specs, status=500, mimetype='application/json')
+    return Response(swagger_specs, status=200, mimetype='application/json')

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from flask import url_for, Blueprint, render_template
+import json
 
 
 class Apidoc(Blueprint):
@@ -32,5 +33,8 @@ def swagger_static(filename):
 
 def ui_for(api):
     '''Render a SwaggerUI for a given API'''
+    if api._hide_specs_url:
+        return render_template('swagger-ui.html', title=api.title,
+        specs_json=api.__schema__, specs_url=None)
     return render_template('swagger-ui.html', title=api.title,
                            specs_url=api.specs_url)

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from flask import url_for, Blueprint, render_template
-import json
 
 
 class Apidoc(Blueprint):

--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -50,11 +50,7 @@
     <script type="text/javascript">
         window.onload = function() {
             const ui = window.ui = new SwaggerUIBundle({
-                {% if specs_json is defined %}
                 spec: {{ specs_json | tojson}},
-                {% else %}
-                url: "{{ specs_url }}",
-                {%- endif %}
                 {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
                 oauth2RedirectUrl: "{{ url_for('restplus_doc.static', filename='oauth2-redirect.html', _external=True) }}",
                 {%- endif %}

--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -50,7 +50,11 @@
     <script type="text/javascript">
         window.onload = function() {
             const ui = window.ui = new SwaggerUIBundle({
+                {% if specs_json is defined %}
+                spec: {{ specs_json | tojson}},
+                {% else %}
                 url: "{{ specs_url }}",
+                {%- endif %}
                 {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
                 oauth2RedirectUrl: "{{ url_for('restplus_doc.static', filename='oauth2-redirect.html', _external=True) }}",
                 {%- endif %}

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -5,7 +5,7 @@ pytest==4.6.5; python_version < '3.5'
 pytest==5.0.1; python_version >= '3.5'
 pytest-benchmark==3.2.2
 pytest-cov==2.7.1
-pytest-flask==0.15.0
+pytest-flask==0.15.1
 pytest-mock==1.10.4
 pytest-profiling==1.7.0
 pytest-sugar==0.9.2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,6 +95,15 @@ class APITest(object):
         resp = client.get('/swagger.json')
         assert resp.status_code == 404
 
+    def test_specs_endpoint_is_hidden(self, app, client):
+        api = restplus.Api()
+        api.init_app(app, hide_specs_url=True)
+        resp = client.get('/swagger.json')
+        assert resp.status_code == 404
+        resp = client.get('/')
+        assert resp.status_code == 200
+
+
     def test_default_endpoint(self, app):
         api = restplus.Api(app)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,14 +95,6 @@ class APITest(object):
         resp = client.get('/swagger.json')
         assert resp.status_code == 404
 
-    def test_specs_endpoint_is_hidden(self, app, client):
-        api = restplus.Api()
-        api.init_app(app, hide_specs_url=True)
-        resp = client.get('/swagger.json')
-        assert resp.status_code == 404
-        resp = client.get('/')
-        assert resp.status_code == 200
-
     def test_default_endpoint(self, app):
         api = restplus.Api(app)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,7 +103,6 @@ class APITest(object):
         resp = client.get('/')
         assert resp.status_code == 200
 
-
     def test_default_endpoint(self, app):
         api = restplus.Api(app)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -413,7 +413,7 @@ class ErrorsTest(object):
 
         response = client.get("/foo")
         assert response.status_code == 404
-        assert response.headers['Content-Type'] == 'text/html'
+        assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_non_api_error_404_catchall(self, app, client):
         api = restplus.Api(app, catch_all_404s=True)


### PR DESCRIPTION
Swagger.json is insecure endpoint

exposed specs endpoint so it can be authorized

@api.specs
@auth.login_required
def custom_swagger_ui():
    """
    Redirect to basic auth, using customer name and token as the password
    """
    return apidoc.specs_for(api)